### PR TITLE
Implement the tombstone pattern for the vote entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "assert-plus": "1.0.0",
         "joi": "17.4.0",
+        "lodash.groupby": "4.6.0",
+        "lodash.ismatch": "4.4.0",
+        "moment": "2.29.1",
         "seneca": "3.23.2",
         "seneca-entity": "13.0.0",
         "seneca-promisify": "2.0.0"
@@ -1284,6 +1287,11 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -1293,6 +1301,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isdate/-/lodash.isdate-4.0.1.tgz",
       "integrity": "sha1-NaVDZzuddhEN5BFLMsxXcEin82Y="
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
     },
     "node_modules/lodash.isnan": {
       "version": "3.0.2",
@@ -1370,6 +1383,14 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -3247,6 +3268,11 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -3256,6 +3282,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isdate/-/lodash.isdate-4.0.1.tgz",
       "integrity": "sha1-NaVDZzuddhEN5BFLMsxXcEin82Y="
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
     },
     "lodash.isnan": {
       "version": "3.0.2",
@@ -3324,6 +3355,11 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "assert-plus": "1.0.0",
     "joi": "17.4.0",
+    "lodash.groupby": "4.6.0",
+    "lodash.ismatch": "4.4.0",
+    "moment": "2.29.1",
     "seneca": "3.23.2",
     "seneca-entity": "13.0.0",
     "seneca-promisify": "2.0.0"

--- a/services/cast_vote/index.js
+++ b/services/cast_vote/index.js
@@ -24,33 +24,12 @@ class CastVoteService {
         throw new NotFoundError(`Poll with id ${poll_id} does not exist.`)
       }
 
-
-      const existing_vote = await Vote.entity({ seneca })
-        .load$({
-          voter_id,
-          voter_type,
-          poll_id
-        })
-
-      if (existing_vote) {
-        const existing_vote_type = fetchProp(existing_vote, 'type')
-
-        if (vote_type !== existing_vote_type) {
-          await existing_vote 
-            .data$({ type: vote_type })
-            .save$()
-        }
-
-        return
-      }
-
       const vote_attributes = {
         poll_id,
-        type: vote_type,
         voter_id,
         voter_type,
-        created_at: new Date(),
-        updated_at: null
+        type: vote_type,
+        created_at: new Date()
       }
 
       const _new_vote = await Vote.entity({ seneca })

--- a/services/get_vote_stats_for_poll/index.js
+++ b/services/get_vote_stats_for_poll/index.js
@@ -1,6 +1,8 @@
 const Assert = require('assert-plus')
 const Poll = require('../../entities/sys/poll')
 const Vote = require('../../entities/sys/vote')
+const groupBy = require('lodash.groupby')
+const isMatch = require('lodash.ismatch')
 const { fetchProp } = require('../../lib/utils')
 
 class GetPollVoteStats {
@@ -11,15 +13,61 @@ class GetPollVoteStats {
     const seneca = fetchProp(ctx, 'seneca')
     const poll_id = fetchProp(args, 'poll_id')
 
-    const numVotesForThePollWhere = poll_attrs =>
-      Vote.entity({ seneca })
-        .list$({ ...poll_attrs, poll_id })
-        .then(votes => votes.length)
-
     const num_upvotes = await numVotesForThePollWhere({ type: Vote.TYPE_UP() })
     const num_downvotes = await numVotesForThePollWhere({ type: Vote.TYPE_DOWN() })
 
     return { num_upvotes, num_downvotes }
+
+
+    function numVotesForThePollWhere(poll_attrs) {
+      return Vote.entity({ seneca })
+        .list$({ poll_id })
+        .then(groupVotesByVoter)
+        .then(votes_by_voter => {
+          return votes_by_voter.map(votes => {
+            Assert.array(votes, 'votes')
+            Assert(votes.length > 0, 'votes.length')
+
+            const [actual_vote,] = votes.sort(desc(byDateOfVote))
+
+            return actual_vote
+          })
+        })
+        .then(actual_votes => actual_votes.filter(vote => isMatch(vote, poll_attrs)))
+        .then(votes => votes.length)
+
+
+      function groupVotesByVoter(votes) {
+        Assert.array(votes, 'votes')
+
+        const groups = groupBy(votes, byVoter)
+
+        return Object.values(groups)
+      }
+
+      function byVoter(vote) {
+        Assert.object(vote, 'vote')
+
+        const voter_id = fetchProp(vote, 'voter_id', Assert.string)
+        const voter_type = fetchProp(vote, 'voter_type', Assert.string)
+
+        return [voter_id, voter_type].join('.')
+      }
+
+      function byDateOfVote(vote1, vote2) {
+        Assert.object(vote1, 'vote1')
+        Assert.object(vote2, 'vote2')
+
+        const voted_at1 = fetchProp(vote1, 'created_at', Assert.date)
+        const voted_at2 = fetchProp(vote2, 'created_at', Assert.date)
+
+        return voted_at1.getTime() - voted_at2.getTime()
+      }
+
+      function desc(cmp) {
+        return (x, y) => -1 * cmp(x, y)
+      }
+    }
   }
 }
 

--- a/test/support/helpers.js
+++ b/test/support/helpers.js
@@ -1,6 +1,12 @@
 const Assert = require('assert-plus')
+const moment = require('moment')
 
 class TestHelpers {
+  static yesterday(date = new Date()) {
+    Assert.date(date, 'date')
+    return moment(date).subtract(1, 'day').toDate()
+  }
+
   static fetchProp(base, prop, assertType = (x, msg) => {}) {
     if (base === null || base === undefined) {
       Assert.fail('Object cannot be null or undefined.')


### PR DESCRIPTION
_Note to self_: there will be a problem when two votes for the same poll by the same voter are cast simultaneously. Better introduce the `version` field on top of the `created_at` timestamp.
